### PR TITLE
Respect next parameter when logging in with SAML

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -160,6 +160,9 @@ def acs(r):
     saml_client = _get_saml_client(get_current_domain(r))
     resp = r.POST.get('SAMLResponse', None)
     next_url = r.session.get('login_next_url', _default_next_url())
+    # use relay state to redirect due to issue described here
+    # https://github.com/fangli/django-saml2-auth/issues/112
+    next_url = r.POST.get('RelayState', next_url)
 
     if not resp:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
@@ -252,7 +255,7 @@ def signin(r):
     r.session['login_next_url'] = next_url
 
     saml_client = _get_saml_client(get_current_domain(r))
-    _, info = saml_client.prepare_for_authenticate()
+    _, info = saml_client.prepare_for_authenticate(relay_state=next_url)
 
     redirect_url = None
 


### PR DESCRIPTION
replicating the fix here: https://github.com/passth/django-saml2-auth/pull/4
addresses https://github.com/WPI-LNL/lnldb/issues/812